### PR TITLE
feat(api): Add support for open-library

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:http/http.dart';
 
 import './model.dart';
@@ -25,4 +26,42 @@ Future<Book?> fetchBookFromGoogle(String isbn, {Client? client}) async {
   } else {
     return null;
   }
+}
+
+Future<Book?> fetchBookFromOpenLibrary(String isbn, {Client? client}) async {
+  client ??= Client();
+
+  var url = Uri(
+    scheme: 'https',
+    host: 'www.openlibrary.org',
+    path: '/isbn/$isbn.json',
+  );
+  var response = await client.get(url);
+  if (response.statusCode == HttpStatus.notFound) {
+    return null;
+  }
+
+  var body = jsonDecode(response.body);
+  var title = body['title'];
+  var publishedYear = body['publish_date'].split(" ")[2];
+  var authorReferences = List<Map<String, dynamic>>.from(body['authors']);
+
+  List<String> authors = [];
+  for (var authorReference in authorReferences) {
+    authors
+        .add(await fetchAuthorFromOpenLibrary(authorReference['key']!, client));
+  }
+
+  return Book(isbn, authors, title, int.parse(publishedYear));
+}
+
+Future<String> fetchAuthorFromOpenLibrary(String key, Client client) async {
+  var url = Uri(
+    scheme: 'https',
+    host: 'www.openlibrary.org',
+    path: '$key.json',
+  );
+  var response = await client.get(url);
+  var body = jsonDecode(response.body);
+  return body['personal_name'];
 }

--- a/lib/database.dart
+++ b/lib/database.dart
@@ -36,11 +36,16 @@ const migrations = [
     'INSERT INTO configs (key, value) VALUES ("enabledAPIs", \'["google"]\');'
   ], [
     'DROP TABLE configs;',
+  ]),
+  Migration([
+    'UPDATE configs SET value=\'["google", "open-library"]\' WHERE key="enabledAPIs";'
+  ], [
+    'UPDATE configs SET value=\'["google", "google"]\' WHERE key="enabledAPIs";'
   ])
 ];
 
 Future<Database> connectToDatabase(
-    {int version = 3,
+    {int version = 4,
     List<Migration> migrations = migrations,
     bool isInMemory = false}) async {
   var dbPath = join(await getDatabasesPath(), 'library.db');

--- a/lib/pages/create.dart
+++ b/lib/pages/create.dart
@@ -24,6 +24,7 @@ class _NewBookPageState extends State<NewBookPage> {
   List<String> enabledAPIs = [];
   Map<String, FetchBook> apiByName = {
     'google': fetchBookFromGoogle,
+    'open-library': fetchBookFromOpenLibrary,
   };
 
   _NewBookPageState() {

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -56,6 +56,13 @@ class _SettingsPageState extends State<SettingsPage> {
               modifyAPIs('google', value);
             },
             value: enabledAPIs.contains('google'),
+          ),
+          CheckboxListTile(
+            title: const Text('Enable Open Library API'),
+            onChanged: (bool? value) {
+              modifyAPIs('google', value);
+            },
+            value: enabledAPIs.contains('open-library'),
           )
         ],
       ),

--- a/test/api_test.dart
+++ b/test/api_test.dart
@@ -64,4 +64,60 @@ void main() {
       });
     }
   });
+
+  group('Open library API', (() {
+    var book = generateBook();
+    var bookURL = Uri(
+        scheme: 'https',
+        host: 'www.openlibrary.org',
+        path: '/isbn/${book.isbn}.json');
+    var authorReferences =
+        book.authors.map((author) => {'key': '/$author'}).toList();
+
+    test('able to fetch book', () async {
+      final client = mocks.MockClient();
+
+      when(client.get(bookURL)).thenAnswer(
+        (_) async => http.Response(
+            jsonEncode({
+              "title": book.title,
+              "authors": authorReferences,
+              "publish_date": 'October 1, ${book.published}',
+            }),
+            200),
+      );
+      book.authors.forEach((author) {
+        var authorURL = Uri(
+            scheme: 'https',
+            host: 'www.openlibrary.org',
+            path: '/$author.json');
+        when(client.get(authorURL)).thenAnswer(
+          (_) async => http.Response(
+              jsonEncode({
+                'personal_name': author,
+              }),
+              200),
+        );
+      });
+
+      var actualBook =
+          await fetchBookFromOpenLibrary(book.isbn, client: client);
+
+      expect(actualBook, isA<Book>());
+      expect('$actualBook', '$book');
+    });
+
+    test('returns null when book not found', () async {
+      final client = mocks.MockClient();
+
+      when(client.get(bookURL)).thenAnswer(
+        (_) async => http.Response(jsonEncode({}), 404),
+      );
+
+      var actualBook =
+          await fetchBookFromOpenLibrary(book.isbn, client: client);
+
+      expect(actualBook, null);
+    });
+  }));
 }


### PR DESCRIPTION
**Scope**
- To increase the chance of finding a book a new API endpoint is configured which queries the information from the open library's public API.

**Development**
 - Created migration to add `open-library` as a default enabled API
 - Added a new setting to toggle the `open-library` API
 - Created an implementation for accessing the open library API