### PR TITLE
refact(main): Inject inject database to pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:digital_library/database.dart';
 import 'package:flutter/material.dart';
+import 'package:sqflite/sqflite.dart';
 
 import 'pages/create.dart';
 import 'pages/home.dart';
@@ -6,11 +8,15 @@ import 'pages/library.dart';
 import 'pages/settings.dart';
 
 void main() {
-  runApp(const MyApp());
+  WidgetsFlutterBinding.ensureInitialized();
+  connectToDatabase().then((db) {
+    runApp(MyApp(db));
+  });
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  final Database db;
+  const MyApp(this.db, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -22,9 +28,9 @@ class MyApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const HomePage(),
-        '/settings': (context) => const SettingsPage(),
-        '/library': (context) => const LibraryPage(),
-        '/add-book': (context) => const NewBookPage(),
+        '/settings': (context) => SettingsPage(db),
+        '/library': (context) => LibraryPage(db),
+        '/add-book': (context) => NewBookPage(db),
       },
     );
   }

--- a/lib/pages/create.dart
+++ b/lib/pages/create.dart
@@ -5,11 +5,12 @@ import 'package:sqflite/sqflite.dart';
 import 'package:digital_library/components/page_layout.dart';
 import 'package:digital_library/api.dart';
 import 'package:digital_library/model.dart';
-import 'package:digital_library/database.dart';
 import 'package:digital_library/storage.dart';
 
 class NewBookPage extends StatefulWidget {
-  const NewBookPage({Key? key}) : super(key: key);
+  final Database db;
+
+  const NewBookPage(this.db, {Key? key}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _NewBookPageState();
@@ -27,12 +28,12 @@ class _NewBookPageState extends State<NewBookPage> {
     'open-library': fetchBookFromOpenLibrary,
   };
 
-  _NewBookPageState() {
-    connectToDatabase().then((db) {
-      var configStore = SQLiteConfigStore(db);
-      configStore.retrieveConfig('enabledAPIs').then((fetchedAPIs) {
-        enabledAPIs = List<String>.from(fetchedAPIs);
-      });
+  @override
+  void initState() {
+    super.initState();
+    var configStore = SQLiteConfigStore(widget.db);
+    configStore.retrieveConfig('enabledAPIs').then((fetchedAPIs) {
+      enabledAPIs = List<String>.from(fetchedAPIs);
     });
   }
 
@@ -85,8 +86,7 @@ class _NewBookPageState extends State<NewBookPage> {
         authorControllers.map((controller) => controller.text).toList(),
         titleController.text,
         int.parse(publishYearController.text));
-    Database db = await connectToDatabase();
-    await SQLiteShelf(db).addBook(book);
+    await SQLiteShelf(widget.db).addBook(book);
 
     isbnController.clear();
     titleController.clear();

--- a/lib/pages/library.dart
+++ b/lib/pages/library.dart
@@ -7,9 +7,11 @@ import 'package:digital_library/exporter.dart';
 import 'package:digital_library/model.dart';
 import 'package:digital_library/storage.dart';
 import 'package:digital_library/components/list.dart';
+import 'package:sqflite/sqflite.dart';
 
 class LibraryPage extends StatefulWidget {
-  const LibraryPage({Key? key}) : super(key: key);
+  final Database db;
+  const LibraryPage(this.db, {Key? key}) : super(key: key);
 
   @override
   State<LibraryPage> createState() => _LibraryPageState();
@@ -18,13 +20,13 @@ class LibraryPage extends StatefulWidget {
 class _LibraryPageState extends State<LibraryPage> {
   List<Book> books = [];
 
-  _LibraryPageState() {
-    connectToDatabase().then((db) {
-      var shelf = SQLiteShelf(db);
-      shelf.retrieveBooks().then((value) {
-        setState(() {
-          books = value;
-        });
+  @override
+  void initState() {
+    super.initState();
+    var shelf = SQLiteShelf(widget.db);
+    shelf.retrieveBooks().then((value) {
+      setState(() {
+        books = value;
       });
     });
   }

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:sqflite/sqlite_api.dart';
 
 import 'package:digital_library/components/page_layout.dart';
-import 'package:digital_library/database.dart';
 import 'package:digital_library/storage.dart';
 
 class SettingsPage extends StatefulWidget {
-  const SettingsPage({Key? key}) : super(key: key);
+  final Database db;
+
+  const SettingsPage(this.db, {Key? key}) : super(key: key);
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -15,14 +17,14 @@ class _SettingsPageState extends State<SettingsPage> {
   late ConfigStore configStore;
   List<String> enabledAPIs = [];
 
-  _SettingsPageState() {
-    connectToDatabase().then((db) {
-      configStore = SQLiteConfigStore(db);
+  @override
+  void initState() {
+    super.initState();
+    configStore = SQLiteConfigStore(widget.db);
 
-      configStore.retrieveConfig('enabledAPIs').then((fetchedAPIs) {
-        setState(() {
-          enabledAPIs = List<String>.from(fetchedAPIs);
-        });
+    configStore.retrieveConfig('enabledAPIs').then((fetchedAPIs) {
+      setState(() {
+        enabledAPIs = List<String>.from(fetchedAPIs);
       });
     });
   }
@@ -60,7 +62,7 @@ class _SettingsPageState extends State<SettingsPage> {
           CheckboxListTile(
             title: const Text('Enable Open Library API'),
             onChanged: (bool? value) {
-              modifyAPIs('google', value);
+              modifyAPIs('open-library', value);
             },
             value: enabledAPIs.contains('open-library'),
           )


### PR DESCRIPTION
**Scope**
 - The `connectToDatabase` method was called all over the place inside the widgets up until this point
 - Instead of this it should be injected from the `main` method to the app

**Development**
 - Setup db connection in the `main` method
 - Refactor pages such that
   - they recieve the `db` in their contructor
   - the used states setup the initial state in the `initState` method