### PR TITLE
refact(`/book/search`): Refactor api endpoint to use db

### DIFF
--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
-
 from fastapi import FastAPI
 from pydantic import BaseSettings
+from sqlalchemy import create_engine
 
 from .api import BOOK_APIS
 
@@ -15,9 +15,15 @@ settings = Settings()
 app = FastAPI()
 
 
-@lru_cache()
-def get_settings():
-    return settings
+@lru_cache
+def get_configurations():
+    from .api import BOOK_APIS  # NOQA F401
+    from .database.uow import SQLUnitOfWork  # NOQA F401
+
+    return {
+        'uow': SQLUnitOfWork(create_engine(settings.database_url)),
+        'configured_apis': BOOK_APIS
+    }
 
 
 from .routes import *  # NOQA: F401 F403 E402

--- a/server/src/api.py
+++ b/server/src/api.py
@@ -20,7 +20,7 @@ def fetch_book_from_google(isbn: str):
 
     published = int(volume['publishedDate'].split('-')[0])
     authors = [
-        Author(name=author_data['name']) for author_data in volume['authors']
+        Author(name=author_data) for author_data in volume['authors']
     ]
     title = volume['title']
 

--- a/server/src/base/repositories.py
+++ b/server/src/base/repositories.py
@@ -8,11 +8,11 @@ from src.models import Book
 class AbstractBookRepository(ABC):
 
     @abstractmethod
-    def getById(self, id: uuid.UUID) -> Book:
+    def getById(self, id: uuid.UUID) -> Book | None:
         raise NotImplementedError
 
     @abstractmethod
-    def getByISBN(self, isbn: int) -> Book:
+    def getByISBN(self, isbn: int) -> Book | None:
         raise NotImplementedError
 
     def getAll(self) -> list:

--- a/server/src/database/repositories.py
+++ b/server/src/database/repositories.py
@@ -9,10 +9,12 @@ class SQLBookRepository(repositories.AbstractBookRepository):
         self.session = session
 
     def getById(self, id):
-        return self.session.query(models.Book).filter_by(id=id).one()
+        return self.session.query(models.Book).filter_by(id=id).one_or_none()
 
     def getByISBN(self, isbn: int):
-        return self.session.query(models.Book).filter_by(isbn=isbn).one()
+        return (
+            self.session.query(models.Book).filter_by(isbn=isbn).one_or_none()
+        )
 
     def getAll(self):
         return self.session.query(models.Book).all()

--- a/server/src/routes.py
+++ b/server/src/routes.py
@@ -1,12 +1,21 @@
 from fastapi import HTTPException, Depends
+from fastapi.encoders import jsonable_encoder
 
-from . import app, get_settings
+from . import app, get_configurations
 
 
 @app.get("/books/search/{isbn}")
-async def search_book(isbn: str, settings=Depends(get_settings)):
-    for api in settings.configured_apis:
-        if book := api(isbn):
-            return book
+async def search_book(isbn: str, configurations=Depends(get_configurations)):
+    uow = configurations['uow']
+
+    with uow:
+        if book := uow.books.getByISBN(isbn):
+            return jsonable_encoder(book)
+
+        for api in configurations['configured_apis']:
+            if book := api(isbn):
+                uow.books.add(book)
+                uow.commit()
+                return jsonable_encoder(book)
 
     raise HTTPException(status_code=404, detail="Book not found")

--- a/server/tests/database/test_uow.py
+++ b/server/tests/database/test_uow.py
@@ -47,4 +47,3 @@ class TestSQLUnitOfWork:
 
             assert fetched_book == book
             assert isinstance(self.uow.books, repositories.SQLBookRepository)
-

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -20,7 +20,7 @@ class TestFetchFromGoogle:
                 'volumeInfo': {
                     'title': self.book.title,
                     'authors': [
-                        {'name': author.name} for author in self.book.authors
+                        author.name for author in self.book.authors
                     ],
                     'publishedDate': f'{self.book.published}-11-1'
                 }

--- a/server/tests/test_routes.py
+++ b/server/tests/test_routes.py
@@ -4,29 +4,50 @@ from unittest.mock import MagicMock
 from http import HTTPStatus
 from fastapi.encoders import jsonable_encoder
 
-from src import Settings
-
 
 class TestSearchBook:
     def test_returns_book_when_fetched_from_api(
-        self, test_client, create_book, settings_override
+        self, test_client, create_book, settings_override, uow
     ):
         book = create_book()
         mock_api = MagicMock(return_value=book)
-        settings = Settings(configured_apis=[mock_api])
-        settings_override(settings)
+        settings_override({
+            'configured_apis': [mock_api],
+            'uow': uow
+        })
 
         response = test_client.get(f"/books/search/{book.isbn}")
         assert response.status_code == HTTPStatus.OK
         assert jsonable_encoder(book) == json.loads(response.read().decode())
+        assert uow.books.calls[0] == ['getByISBN', [book.isbn]]
+        assert uow.books.calls[1] == ['add', [book]]
         mock_api.assert_called_once_with(book.isbn)
 
+    def test_returns_book_when_found_in_repository(
+        self, test_client, create_book, settings_override, uow
+    ):
+        book = create_book()
+        uow.books.result = book
+        mock_api = MagicMock(return_value=book)
+        settings_override({
+            'configured_apis': [mock_api],
+            'uow': uow
+        })
+
+        response = test_client.get(f"/books/search/{book.isbn}")
+        assert response.status_code == HTTPStatus.OK
+        assert jsonable_encoder(book) == json.loads(response.read().decode())
+        mock_api.assert_not_called()
+        assert uow.books.calls == [['getByISBN', [book.isbn]]]
+
     def test_returns_not_found_when_book_can_not_be_fetched(
-        self, test_client, settings_override
+        self, test_client, settings_override, uow
     ):
         mock_api = MagicMock(return_value=None)
-        settings = Settings(configured_apis=[mock_api])
-        settings_override(settings)
+        settings_override({
+            'configured_apis': [mock_api],
+            'uow': uow
+        })
 
         response = test_client.get("/books/search/1")
 


### PR DESCRIPTION
**Scope**
 - Now that we have a proper databas setup, where we could store the books as well as we can fetched them we should use that db to fetch the books from there, rather then from an API

**Development**
 - Refactored book repository, such that it can return `None` when fetching book by id or isbn
 - Refactored endpoint such that first it tries to find the book in the database, and only after that fetches the configured APIs
 - Seperated `Settings` from `configurations`, where settings contains enviroment variable and configuration python dependencies