### PR TITLE
feat(server): Create basic user creation and autentication

### DIFF
--- a/server/Pipfile
+++ b/server/Pipfile
@@ -10,6 +10,10 @@ sqlalchemy = "*"
 alembic = "*"
 psycopg2-binary = "*"
 passlib = "*"
+email-validator = "*"
+python-jose = {extras = ["cryptography"], version = "*"}
+install = "*"
+python-multipart = "*"
 
 [dev-packages]
 httpx = "*"

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f05b3ed496006daae55ad991724f7bc34e958ef34745ba41961f745ba129bd04"
+            "sha256": "2d33678e33e9b89f428d77b0f9eae642c198bb36453313e631bd006c32778654"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:dd4718279975ea50d0602a3a00a9811bc9bb4b744ac9abf5fafbf52ac63b1f6a",
-                "sha256:f9cc3fbf0a3c60f8de959bb5c195586618d7ce37e7033e3dfc59396b7889a5e1"
+                "sha256:457eafbdc0769d855c2c92cbafe6b7f319f916c80cf4ed02b8f394f38b51b89d",
+                "sha256:8b48368f6533c064b39c024e1daba15ae7f947eac84185c28c06bbe1301a5497"
             ],
             "index": "pypi",
-            "version": "==1.10.0"
+            "version": "==1.10.2"
         },
         "anyio": {
             "hashes": [
@@ -32,6 +32,75 @@
             "markers": "python_full_version >= '3.6.2'",
             "version": "==3.6.2"
         },
+        "cffi": {
+            "hashes": [
+                "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
+                "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
+                "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
+                "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
+                "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
+                "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
+                "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
+                "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
+                "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
+                "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
+                "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+                "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
+                "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+                "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
+                "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
+                "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
+                "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+                "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
+                "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
+                "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
+                "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
+                "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
+                "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
+                "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2",
+                "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
+                "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
+                "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+                "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
+                "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
+                "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+                "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
+                "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
+                "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
+                "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
+                "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
+                "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
+                "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
+                "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
+                "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
+                "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
+                "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
+                "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
+                "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
+                "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
+                "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
+                "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
+                "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
+                "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
+                "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
+                "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
+                "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
+                "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
+                "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
+                "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
+                "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
+                "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
+                "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
+                "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
+                "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
+                "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
+                "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
+                "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
+                "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
+                "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"
+            ],
+            "version": "==1.15.1"
+        },
         "click": {
             "hashes": [
                 "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
@@ -40,13 +109,62 @@
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
         },
-        "fastapi": {
+        "cryptography": {
             "hashes": [
-                "sha256:023a0f5bd2c8b2609014d3bba1e14a1d7df96c6abea0a73070621c9862b9a4de",
-                "sha256:ae7b97c778e2f2ec3fb3cb4fb14162129411d99907fb71920f6d69a524340ebf"
+                "sha256:0a4e3406cfed6b1f6d6e87ed243363652b2586b2d917b0609ca4f97072994405",
+                "sha256:1e0af458515d5e4028aad75f3bb3fe7a31e46ad920648cd59b64d3da842e4356",
+                "sha256:2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472",
+                "sha256:28d63d75bf7ae4045b10de5413fb1d6338616e79015999ad9cf6fc538f772d41",
+                "sha256:32057d3d0ab7d4453778367ca43e99ddb711770477c4f072a51b3ca69602780a",
+                "sha256:3a4805a4ca729d65570a1b7cac84eac1e431085d40387b7d3bbaa47e39890b88",
+                "sha256:63dac2d25c47f12a7b8aa60e528bfb3c51c5a6c5a9f7c86987909c6c79765554",
+                "sha256:650883cc064297ef3676b1db1b7b1df6081794c4ada96fa457253c4cc40f97db",
+                "sha256:6f2bbd72f717ce33100e6467572abaedc61f1acb87b8d546001328d7f466b778",
+                "sha256:7c872413353c70e0263a9368c4993710070e70ab3e5318d85510cc91cce77e7c",
+                "sha256:918cb89086c7d98b1b86b9fdb70c712e5a9325ba6f7d7cfb509e784e0cfc6917",
+                "sha256:9618a87212cb5200500e304e43691111570e1f10ec3f35569fdfcd17e28fd797",
+                "sha256:a805a7bce4a77d51696410005b3e85ae2839bad9aa38894afc0aa99d8e0c3160",
+                "sha256:cc3a621076d824d75ab1e1e530e66e7e8564e357dd723f2533225d40fe35c60c",
+                "sha256:cd033d74067d8928ef00a6b1327c8ea0452523967ca4463666eeba65ca350d4c",
+                "sha256:cf91e428c51ef692b82ce786583e214f58392399cf65c341bc7301d096fa3ba2",
+                "sha256:d36bbeb99704aabefdca5aee4eba04455d7a27ceabd16f3b3ba9bdcc31da86c4",
+                "sha256:d8aa3609d337ad85e4eb9bb0f8bcf6e4409bfb86e706efa9a027912169e89122",
+                "sha256:f5d7b79fa56bc29580faafc2ff736ce05ba31feaa9d4735048b0de7d9ceb2b94"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==40.0.1"
+        },
+        "dnspython": {
+            "hashes": [
+                "sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9",
+                "sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==2.3.0"
+        },
+        "ecdsa": {
+            "hashes": [
+                "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49",
+                "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.18.0"
+        },
+        "email-validator": {
+            "hashes": [
+                "sha256:49a72f5fa6ed26be1c964f0567d931d10bf3fdeeacdf97bc26ef1cd2a44e0bda",
+                "sha256:d178c5c6fa6c6824e9b04f199cf23e79ac15756786573c190d2ad13089411ad2"
             ],
             "index": "pypi",
-            "version": "==0.92.0"
+            "version": "==1.3.1"
+        },
+        "fastapi": {
+            "hashes": [
+                "sha256:99d4fdb10e9dd9a24027ac1d0bd4b56702652056ca17a6c8721eec4ad2f14e18",
+                "sha256:daf73bbe844180200be7966f68e8ec9fd8be57079dff1bacb366db32729e6eb5"
+            ],
+            "index": "pypi",
+            "version": "==0.95.0"
         },
         "greenlet": {
             "hashes": [
@@ -129,6 +247,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
+        },
+        "install": {
+            "hashes": [
+                "sha256:0d3fadf4aa62c95efe8d34757c8507eb46177f86c016c21c6551eafc6a53d5a9",
+                "sha256:e67c8a0be5ccf8cb4ffa17d090f3a61b6e820e6a7e21cd1d2c0f7bc59b18e647"
+            ],
+            "index": "pypi",
+            "version": "==1.3.5"
         },
         "mako": {
             "hashes": [
@@ -279,47 +405,107 @@
             "index": "pypi",
             "version": "==2.9.5"
         },
+        "pyasn1": {
+            "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
+                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+            ],
+            "version": "==0.4.8"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+            ],
+            "version": "==2.21"
+        },
         "pydantic": {
             "hashes": [
-                "sha256:1fd326aff5d6c36f05735c7c9b3d5b0e933b4ca52ad0b6e4b38038d82703d35b",
-                "sha256:2185a3b3d98ab4506a3f6707569802d2d92c3a7ba3a9a35683a7709ea6c2aaa2",
-                "sha256:261f357f0aecda005934e413dfd7aa4077004a174dafe414a8325e6098a8e419",
-                "sha256:305d0376c516b0dfa1dbefeae8c21042b57b496892d721905a6ec6b79494a66d",
-                "sha256:3257bd714de9db2102b742570a56bf7978e90441193acac109b1f500290f5718",
-                "sha256:3353072625ea2a9a6c81ad01b91e5c07fa70deb06368c71307529abf70d23325",
-                "sha256:36e44a4de37b8aecffa81c081dbfe42c4d2bf9f6dff34d03dce157ec65eb0f15",
-                "sha256:3bb99cf9655b377db1a9e47fa4479e3330ea96f4123c6c8200e482704bf1eda2",
-                "sha256:3f9d9b2be177c3cb6027cd67fbf323586417868c06c3c85d0d101703136e6b31",
-                "sha256:45edea10b75d3da43cfda12f3792833a3fa70b6eee4db1ed6aed528cef17c74e",
-                "sha256:51782fd81f09edcf265823c3bf43ff36d00db246eca39ee765ef58dc8421a642",
-                "sha256:532e97c35719f137ee5405bd3eeddc5c06eb91a032bc755a44e34a712420daf3",
-                "sha256:58e41dd1e977531ac6073b11baac8c013f3cd8706a01d3dc74e86955be8b2c0c",
-                "sha256:5920824fe1e21cbb3e38cf0f3dd24857c8959801d1031ce1fac1d50857a03bfb",
-                "sha256:5f3bc8f103b56a8c88021d481410874b1f13edf6e838da607dcb57ecff9b4594",
-                "sha256:63200cd8af1af2c07964546b7bc8f217e8bda9d0a2ef0ee0c797b36353914984",
-                "sha256:663d2dd78596c5fa3eb996bc3f34b8c2a592648ad10008f98d1348be7ae212fb",
-                "sha256:6a4b0aab29061262065bbdede617ef99cc5914d1bf0ddc8bcd8e3d7928d85bd6",
-                "sha256:6bb0452d7b8516178c969d305d9630a3c9b8cf16fcf4713261c9ebd465af0d73",
-                "sha256:72ef3783be8cbdef6bca034606a5de3862be6b72415dc5cb1fb8ddbac110049a",
-                "sha256:76c930ad0746c70f0368c4596020b736ab65b473c1f9b3872310a835d852eb19",
-                "sha256:7c5b94d598c90f2f46b3a983ffb46ab806a67099d118ae0da7ef21a2a4033b28",
-                "sha256:7ce1612e98c6326f10888df951a26ec1a577d8df49ddcaea87773bfbe23ba5cc",
-                "sha256:8481dca324e1c7b715ce091a698b181054d22072e848b6fc7895cd86f79b4449",
-                "sha256:87f831e81ea0589cd18257f84386bf30154c5f4bed373b7b75e5cb0b5d53ea87",
-                "sha256:9a9d9155e2a9f38b2eb9374c88f02fd4d6851ae17b65ee786a87d032f87008f8",
-                "sha256:9e337ac83686645a46db0e825acceea8e02fca4062483f40e9ae178e8bd1103a",
-                "sha256:b429f7c457aebb7fbe7cd69c418d1cd7c6fdc4d3c8697f45af78b8d5a7955760",
-                "sha256:b473d00ccd5c2061fd896ac127b7755baad233f8d996ea288af14ae09f8e0d1e",
-                "sha256:bd46a0e6296346c477e59a954da57beaf9c538da37b9df482e50f836e4a7d4bb",
-                "sha256:c428c0f64a86661fb4873495c4fac430ec7a7cef2b8c1c28f3d1a7277f9ea5ab",
-                "sha256:c9e5b778b6842f135902e2d82624008c6a79710207e28e86966cd136c621bfee",
-                "sha256:ca9075ab3de9e48b75fa8ccb897c34ccc1519177ad8841d99f7fd74cf43be5bf",
-                "sha256:f582cac9d11c227c652d3ce8ee223d94eb06f4228b52a8adaafa9fa62e73d5c9",
-                "sha256:f5bee6c523d13944a1fdc6f0525bc86dbbd94372f17b83fa6331aabacc8fd08e",
-                "sha256:f836444b4c5ece128b23ec36a446c9ab7f9b0f7981d0d27e13a7c366ee163f8a"
+                "sha256:01aea3a42c13f2602b7ecbbea484a98169fb568ebd9e247593ea05f01b884b2e",
+                "sha256:0cd181f1d0b1d00e2b705f1bf1ac7799a2d938cce3376b8007df62b29be3c2c6",
+                "sha256:10a86d8c8db68086f1e30a530f7d5f83eb0685e632e411dbbcf2d5c0150e8dcd",
+                "sha256:193924c563fae6ddcb71d3f06fa153866423ac1b793a47936656e806b64e24ca",
+                "sha256:464855a7ff7f2cc2cf537ecc421291b9132aa9c79aef44e917ad711b4a93163b",
+                "sha256:516f1ed9bc2406a0467dd777afc636c7091d71f214d5e413d64fef45174cfc7a",
+                "sha256:6434b49c0b03a51021ade5c4daa7d70c98f7a79e95b551201fff682fc1661245",
+                "sha256:64d34ab766fa056df49013bb6e79921a0265204c071984e75a09cbceacbbdd5d",
+                "sha256:670bb4683ad1e48b0ecb06f0cfe2178dcf74ff27921cdf1606e527d2617a81ee",
+                "sha256:68792151e174a4aa9e9fc1b4e653e65a354a2fa0fed169f7b3d09902ad2cb6f1",
+                "sha256:701daea9ffe9d26f97b52f1d157e0d4121644f0fcf80b443248434958fd03dc3",
+                "sha256:7d45fc99d64af9aaf7e308054a0067fdcd87ffe974f2442312372dfa66e1001d",
+                "sha256:80b1fab4deb08a8292d15e43a6edccdffa5377a36a4597bb545b93e79c5ff0a5",
+                "sha256:82dffb306dd20bd5268fd6379bc4bfe75242a9c2b79fec58e1041fbbdb1f7914",
+                "sha256:8c7f51861d73e8b9ddcb9916ae7ac39fb52761d9ea0df41128e81e2ba42886cd",
+                "sha256:950ce33857841f9a337ce07ddf46bc84e1c4946d2a3bba18f8280297157a3fd1",
+                "sha256:976cae77ba6a49d80f461fd8bba183ff7ba79f44aa5cfa82f1346b5626542f8e",
+                "sha256:9f6f0fd68d73257ad6685419478c5aece46432f4bdd8d32c7345f1986496171e",
+                "sha256:a7cd2251439988b413cb0a985c4ed82b6c6aac382dbaff53ae03c4b23a70e80a",
+                "sha256:abfb7d4a7cd5cc4e1d1887c43503a7c5dd608eadf8bc615413fc498d3e4645cd",
+                "sha256:ae150a63564929c675d7f2303008d88426a0add46efd76c3fc797cd71cb1b46f",
+                "sha256:b0f85904f73161817b80781cc150f8b906d521fa11e3cdabae19a581c3606209",
+                "sha256:b4a849d10f211389502059c33332e91327bc154acc1845f375a99eca3afa802d",
+                "sha256:c15582f9055fbc1bfe50266a19771bbbef33dd28c45e78afbe1996fd70966c2a",
+                "sha256:c230c0d8a322276d6e7b88c3f7ce885f9ed16e0910354510e0bae84d54991143",
+                "sha256:cc1dde4e50a5fc1336ee0581c1612215bc64ed6d28d2c7c6f25d2fe3e7c3e918",
+                "sha256:cf135c46099ff3f919d2150a948ce94b9ce545598ef2c6c7bf55dca98a304b52",
+                "sha256:cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e",
+                "sha256:d2a5ebb48958754d386195fe9e9c5106f11275867051bf017a8059410e9abf1f",
+                "sha256:d71e69699498b020ea198468e2480a2f1e7433e32a3a99760058c6520e2bea7e",
+                "sha256:d75ae19d2a3dbb146b6f324031c24f8a3f52ff5d6a9f22f0683694b3afcb16fb",
+                "sha256:dfe2507b8ef209da71b6fb5f4e597b50c5a34b78d7e857c4f8f3115effaef5fe",
+                "sha256:e0cfe895a504c060e5d36b287ee696e2fdad02d89e0d895f83037245218a87fe",
+                "sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d",
+                "sha256:ecbbc51391248116c0a055899e6c3e7ffbb11fb5e2a4cd6f2d0b93272118a209",
+                "sha256:f4a2b50e2b03d5776e7f21af73e2070e1b5c0d0df255a827e7c632962f8315af"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.10.5"
+            "version": "==1.10.7"
+        },
+        "python-jose": {
+            "extras": [
+                "cryptography"
+            ],
+            "hashes": [
+                "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a",
+                "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"
+            ],
+            "index": "pypi",
+            "version": "==3.3.0"
+        },
+        "python-multipart": {
+            "hashes": [
+                "sha256:e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132",
+                "sha256:ee698bab5ef148b0a760751c261902cd096e57e10558e11aca17646b74ee1c18"
+            ],
+            "index": "pypi",
+            "version": "==0.0.6"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
+                "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==4.9"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "sniffio": {
             "hashes": [
@@ -331,58 +517,58 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:03cd5709839fc376538f102c58f632d48bd0b92715bd290c3b2c066e0dd0f214",
-                "sha256:0433abeb650c72c872e31010bff8536907fb05f6fa29a9b880046570c03383ca",
-                "sha256:059ddd4ddbfb8f1c872d601b168273dfaab0eae458736c7c754187b9a8e92ad5",
-                "sha256:1012c0440108c360b94f43667525365c43516e8c7f1f7de8dfb73471181055df",
-                "sha256:13eb2a5882cfd9f4eedaaec14a5603a096f0125f7c3cb48611b3bfa3c253f25d",
-                "sha256:15c92107437770087ad4fece6ed9553ab97474f3b92d15eb62cea9686228f252",
-                "sha256:1edb6621782f9a3e80750ba1859580b778a424242d4e6b9bcd46fa6beca75c12",
-                "sha256:22f60d214899b573edc8aeb9ba84f7e832505511ce68974636e6da4a27c957a3",
-                "sha256:2bffc27ec0386ef4af7c8923f0f809f88671859b907c9e11f000c39b97195e99",
-                "sha256:2c3869a7bdd5bb76fb50976abe339e30cce8e9f7c778a50811d310ec82cdf51a",
-                "sha256:3c4e673da09af37b7a5c13b947fdb387c3800d43dcd86c1d553e3c70369e4749",
-                "sha256:4756878d0ceb6e0e9c6cfcfaa9df81adbfcca8cc4b9ec37934918008c0f20507",
-                "sha256:50b15fce441b8eb13bfd06df1088aa52c9a3d72d4894e3456040857d48a622da",
-                "sha256:56d38c3638965df5257ac4648ba2887aaf1e3409397192dd85ddfe7b96dc7680",
-                "sha256:5c00d2b3607f9ae5c0827ebb2d01020c26cfce4064aa664db21d1fd6a47f8f60",
-                "sha256:621e92ace804e19da2e472e349736d7ba5e2e4a14d41c4de9e2474e5f40a11ed",
-                "sha256:68c4c5ab13997fa7af37d5780da11ddc184d4e88fb2d8a26525044c233f03bc7",
-                "sha256:6df48bb7af217fd086617aae1f9606ff91cfab9a29c3e77dd80e4bab8aaf29fc",
-                "sha256:72e8d65b20147df71297d863981d8e56e429a8ae2bb835bd5e89efd7ef849866",
-                "sha256:744b01fcdfef66b7373262bf75d714a4339f85c05b74b1732749f25ed65f33f6",
-                "sha256:7e33867e09820c98630f7faec535a8cc4116fd362787404b41883d373437290b",
-                "sha256:7fab3d4062472e1e6002bfcd53cc7446189941be083a5465760aa794092004ee",
-                "sha256:7fe933831e17f93947b4e3db4e4a7470dae24340f269baf06cdfcc0538c8d1cb",
-                "sha256:869ca02661f6d4cece5823997a364dfa97601de11151fca3ebc3429eb9ffa2e0",
-                "sha256:8e7d5766fb99743eb70126daaff45f43bee3f4b79ba6047a0749912e8538f0ff",
-                "sha256:9a4d9a7e9b344bf8ce2ed699baa8a43d9fbdad3aecff259f1d0daf6bb2e7e0c0",
-                "sha256:9bb63e22ddf01cbbb290e61f31471480d2e40283e558cdd924b94dc4fc2e186b",
-                "sha256:a7e55659740e768a1bf1257275b565137a3d28839789c85193dd6a1e642b3cc9",
-                "sha256:ac12d8bef707d02ef179f0586c848db2954668dca2b72c69df950e08dc8cddb4",
-                "sha256:adf597e756e27173be57f243cc17bea7af1ac74b35c0120aace2738f59c92a48",
-                "sha256:b21694c8543becc2bc4f05f8d07970860e6ad005024712b7195abb1f4e0daf47",
-                "sha256:b52be78c5e86ade646c82a10b2be4b6ed8f623052b4405b26681880df1a15d5a",
-                "sha256:c12f0455f30d637644f4d6df2bda1475c61398483edb58d55c670be31a31d549",
-                "sha256:c2c41bf05b4cf4ffead35896affa3b457c17755d0fd83b1ba72f7f55abb3a3f1",
-                "sha256:d6cb241c5c1af422c0fa742bd09a8eaf158da1433617ded1ffcbb56de6ff8047",
-                "sha256:d811b97f58d99e5948752087903cb414fd77a60a5e09293be16c924219178c3b",
-                "sha256:d81b2fa605939c437f8b0b8522ec2c19508f3036d6043cb70a15dd56760ab710",
-                "sha256:e13cea675937125417953fd011138f13cf979051567f48074fffb3bb0b64b917",
-                "sha256:e40c39cfcbe416a7722a226ecd98fad0e08f8ae33e8f94b0858afe094583bfbc",
-                "sha256:f53542654124d30a3c3ebff9f99e5749add75e4cf28895a2ca6cd1458039bd8f",
-                "sha256:ffda70373ddfe8ec733d518e4e41eb5599480d48e8496c44bb0cac0e37b281c0"
+                "sha256:09b6a94bbb1507b3fc75a3c98491f990b80a859eb5227378f6dac908dff74396",
+                "sha256:0cdc65cbb95ae6813c51acffa65dd8d8272a52da42e3967fc98788fe185a0e0c",
+                "sha256:21698ac65afe477400aacb56244b607477c192892e2f7a70492cae1e13f73040",
+                "sha256:250e158a1f36c965dde1f949366eae9a57504a8cd7a4d968e66c2d0b3c18198d",
+                "sha256:2cc70331b7aed25fed5260cf30a69e42eaf3d887a23a6e4f29a51167ae8a00e1",
+                "sha256:32af8923cfe7b115d40b88604412450d2e4714f4b9a69b1966dfe6012e254789",
+                "sha256:337ae79dc63b1c957dd2e9e7eed5235492886e2af45d8df4b28748ee4859b588",
+                "sha256:3a1eb8ed5dc2a7bc554a612a57253f3682aea7e4c54c742153aef6a12fde10ee",
+                "sha256:3ca04c2ccf6f70278905a371ae6eb61494e8c388e98cba909bc9458ceb73dda5",
+                "sha256:42207a5237d8b211df1c04da4a8700bb9f366f5d7be14b1a2e39cc33d330428c",
+                "sha256:4223002ab7faac63384019feb31eab4ae2233753fd06ea95690d4e148b5bf80d",
+                "sha256:50fa610ac1e45e9adc161227cccbd5c75f8eef25b2ad4a0e080d48c27023415d",
+                "sha256:5a64345a6f41c8c011df3f498cee8de39d9682ca2de14698b68a50bf3a03f6e5",
+                "sha256:5b030f91dd310c0f1d7da0654fcc9d8574fe430693e29c544f5558c2426e08eb",
+                "sha256:68b328500a20f328db6af2c6839eb69e3791b2cd544f5808a4b0123b130c7571",
+                "sha256:692a2b1e0c82c678c84ccb3a9a226e0553dd115be3d5c54b1bb6ef35bc464da9",
+                "sha256:6a091b9166ab9d8ff77c3155140105e76df1d585632fb9367a31b517960df78a",
+                "sha256:6c5e056a6dc1ce29d5e0e54bc1ce669f3035ec18cb7e5c853122b5fdfe216f8f",
+                "sha256:6c8e546c249f0d23821f4b31e5adfba8e39bc90140d39f7086d4a8422d1f0fa6",
+                "sha256:6d82bb74a44f103d566f6c86d6db0ed944e99a7da93d6490c1e987a2b91d5613",
+                "sha256:6f33587541eb6eb0292e82b314f5ef53159f63f14ae1c08b5ef6195732523afa",
+                "sha256:7e0f74c66b2d0081cee5093150407ec43d23d0d5c70aa5b41f438ead1d39bc8d",
+                "sha256:81ada150345ef9c709b647e2bcc8f688d62de6b8f06a7544bed76bef328c6636",
+                "sha256:8a215d3e9de2af881c4eee60bf2b3576fb2eeb591a9af37ff2919cd74b68f162",
+                "sha256:8df6722580ff89295e9d11b781d7a50ff6e48fdfe1c81362000925b4d4cbab31",
+                "sha256:9a981a65dc0082009399eac6600b0983120bc3b850f3c1ed986f68648d9dbb4c",
+                "sha256:a1906c954ee7287d46877636a66da157fc83553851013e42c862653ddacb380b",
+                "sha256:aaf42183f93ad3801bc08c8a111de16802a2c32d16dcb9700daf1a8ae12d9d28",
+                "sha256:af0683c905c856db70adf6d0f84398785f7be6cb4ffdad20d8e16fe426bdf6e8",
+                "sha256:b3bdbd9a5b2788b5c51c4fffa2f875103d3c6d01b8f0dc4abbf075cea11741f5",
+                "sha256:b4c73a3537f928ebf687244f2af9d477b3b14640b4472fcb2456ee0193850ba1",
+                "sha256:c2590fd682d3b9dbecb2710ba83b28ba9df18e0c3c26c78bb950715566784723",
+                "sha256:cd405d224c0f83f267bfcc430bd275195cb48bb9576f6949911faec16bba1216",
+                "sha256:cf1447ec09d7c9ef0b3a65cea905690ed78ed88717beaac537271c005b0e4ea2",
+                "sha256:d6753512214d0de6a5a1c05fe716a7d643c927eb0495341db6526577960cbb55",
+                "sha256:d713d8c4b36c4f69eef33a70a4521e37b75a3ac9c86ee96626c4b052337978cc",
+                "sha256:e424a385a234e0bbaac69b6b09894ce99aa285518dd9397846e78214671ec0b4",
+                "sha256:e8707ba6e783d144209dab0324cc72147a1de34d404a61a08eef96fbb3c8909f",
+                "sha256:ea2976a98076f44e7e8ab9a90b6dfa357253edddf687294b1bcd852ffe20e526",
+                "sha256:f12cd526188f36f161eb71fb275b06d1879c565b07cf0ab2c2408c5059df1fed",
+                "sha256:fa72fb1be5e6704d697471eb5cc07bf9cd98689be11ffa724efe2a3666d0f6c1"
             ],
             "index": "pypi",
-            "version": "==2.0.5.post1"
+            "version": "==2.0.8"
         },
         "starlette": {
             "hashes": [
-                "sha256:774f1df1983fd594b9b6fb3ded39c2aa1979d10ac45caac0f4255cbe2acb8628",
-                "sha256:854c71e73736c429c2bdb07801f2c76c9cba497e7c3cf4988fde5e95fe4cdb3c"
+                "sha256:41da799057ea8620e4667a3e69a5b1923ebd32b1819c8fa75634bbe8d8bea9bd",
+                "sha256:e87fce5d7cbdde34b76f0ac69013fd9d190d581d80681493016666e6f96c6d5e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.25.0"
+            "version": "==0.26.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -394,11 +580,11 @@
         },
         "uvicorn": {
             "hashes": [
-                "sha256:a4e12017b940247f836bc90b72e725d7dfd0c8ed1c51eb365f5ba30d9f5127d8",
-                "sha256:c3ed1598a5668208723f2bb49336f4509424ad198d6ab2615b7783db58d919fd"
+                "sha256:0fac9cb342ba099e0d582966005f3fdba5b0290579fed4a6266dc702ca7bb032",
+                "sha256:e47cac98a6da10cd41e6fd036d472c6f58ede6c5dbee3dbee3ef7a100ed97742"
             ],
             "index": "pypi",
-            "version": "==0.20.0"
+            "version": "==0.21.1"
         }
     },
     "develop": {
@@ -505,11 +691,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156",
-                "sha256:735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04"
+                "sha256:1c183bf61b148b00bcebfa5d9b39312733ae97f6dad90d7e9b4d86c8647f498c",
+                "sha256:a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d"
             ],
             "index": "pypi",
-            "version": "==8.11.0"
+            "version": "==8.12.0"
         },
         "jedi": {
             "hashes": [

--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -4,12 +4,15 @@ from pydantic import BaseSettings
 from passlib.context import CryptContext
 from sqlalchemy import create_engine
 
-from .api import BOOK_APIS
-
 
 class Settings(BaseSettings):
-    configured_apis = BOOK_APIS
-    database_url = "postgresql://library_user:library_user@127.0.0.1/library"
+    DATABASE_URL = "postgresql://library_user:library_user@127.0.0.1/library"
+    MINIMUM_PASSWORD_LENGTH = 8
+    # to get a string like this run:
+    # openssl rand -hex 32
+    SECRET_KEY = "dbdac2857bf1c560cebb245794d3ad1f957e3b2e3f06a17c4a7978762676560b" # NOQA E501
+    ALGORITHM = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 
 settings = Settings()
@@ -23,7 +26,7 @@ def get_configurations():
     from .database.uow import SQLUnitOfWork  # NOQA F401
 
     return {
-        'uow': SQLUnitOfWork(create_engine(settings.database_url)),
+        'uow': SQLUnitOfWork(create_engine(settings.DATABASE_URL)),
         'configured_apis': BOOK_APIS
     }
 

--- a/server/src/database/uow.py
+++ b/server/src/database/uow.py
@@ -12,7 +12,10 @@ class SQLUnitOfWork(uow.AbstractUnitOfWork):
 
     def __enter__(self):
         self.session = sessionmaker(
-            autocommit=False, autoflush=False, bind=self.engine
+            autocommit=False,
+            autoflush=False,
+            bind=self.engine,
+            expire_on_commit=False
         )()
         self.books = repositories.SQLBookRepository(self.session)
         self.users = repositories.SQLUserRepository(self.session)

--- a/server/src/models.py
+++ b/server/src/models.py
@@ -27,7 +27,13 @@ class Book:
 class User:
     id: uuid.UUID = field(init=False)
     email: str
-    password: str
+    password: str = field(default='')
 
     def __post_init__(self) -> None:
         self.id = uuid.uuid4()
+
+
+@dataclass
+class Token:
+    access_token: str
+    token_type: str

--- a/server/src/routes.py
+++ b/server/src/routes.py
@@ -1,7 +1,13 @@
-from fastapi import HTTPException, Depends
+from typing import Annotated
+
+from fastapi import Body, Depends, HTTPException, status
 from fastapi.encoders import jsonable_encoder
+from fastapi.security import OAuth2PasswordRequestForm
+
 
 from . import app, get_configurations
+from .models import Token, User
+from .services import authenticate_user, create_access_token, create_user
 
 
 @app.get("/books/search/{isbn}")
@@ -19,3 +25,40 @@ async def search_book(isbn: str, configurations=Depends(get_configurations)):
                 return jsonable_encoder(book)
 
     raise HTTPException(status_code=404, detail="Book not found")
+
+
+@app.post("/token", response_model=Token)
+async def login_for_access_token(
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    configurations=Depends(get_configurations)
+):
+    uow = configurations['uow']
+    user = authenticate_user(uow, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    access_token = create_access_token(user.id)
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.post("/user/create", response_model=User, status_code=201)
+async def create_user_api(
+    email: Annotated[str, Body()],
+    password: Annotated[str, Body()],
+    configurations=Depends(get_configurations)
+):
+    uow = configurations['uow']
+
+    try:
+        user = create_user(uow, email, password)
+
+        return jsonable_encoder(user, exclude=set(['password']))
+    except ValueError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(error)
+        )

--- a/server/src/services.py
+++ b/server/src/services.py
@@ -1,0 +1,89 @@
+import uuid
+
+from datetime import datetime, timedelta
+from email_validator import validate_email, EmailNotValidError
+from jose import jwt, JWTError
+
+from .base.uow import AbstractUnitOfWork
+from .models import User
+from . import password_context, settings
+
+
+user_creation_error = ValueError('Unable to create user!')
+
+
+def create_user(
+    uow: AbstractUnitOfWork,
+    email: str,
+    raw_password: str
+):
+    with uow:
+        try:
+            validate_email(email)
+        except EmailNotValidError:
+            raise user_creation_error
+
+        validate_password(raw_password)
+
+        if uow.users.getByEmail(email) is not None:
+            raise user_creation_error
+
+        password = password_context.hash(raw_password)
+        user = User(email=email, password=password)
+        uow.users.add(user)
+        uow.commit()
+        return user
+
+
+def create_access_token(user_id: uuid.UUID, timestamp=datetime.now()):
+    to_encode = {
+        "sub": str(user_id),
+        "exp": (
+            timestamp
+            + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        )
+    }
+    encoded_jwt = jwt.encode(
+        to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM
+    )
+    return encoded_jwt
+
+
+def authenticate_user(uow: AbstractUnitOfWork, email: str, raw_password: str):
+    with uow:
+        user = uow.users.getByEmail(email)
+
+        if (
+            user is None
+            or not password_context.verify(raw_password, user.password)
+        ):
+            return None
+
+        uow.commit()
+        return user
+
+
+def validate_token(uow: AbstractUnitOfWork, token: str):
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=settings.ALGORITHM
+        )
+        user_id = str(payload.get("sub"))
+        if user_id is None:
+            raise PermissionError('Invalid token provided!')
+    except JWTError:
+        raise PermissionError('Invalid token provided!')
+
+    with uow:
+        user = uow.users.get(uuid.UUID(user_id))
+
+        if user is None:
+            raise PermissionError('Invalid token provided!')
+
+
+def validate_password(password: str):
+    if (
+        password is None
+        or len(password) < settings.MINIMUM_PASSWORD_LENGTH
+    ):
+        raise user_creation_error

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -26,14 +26,16 @@ def settings_override():
     def _(configurations: dict):
         app.dependency_overrides[get_configurations] = lambda: configurations
 
-    return _
+    yield _
+
+    app.dependency_overrides[get_configurations] = get_configurations
 
 
 @pytest.fixture
 def database_engine():
     engine = create_engine(
-        settings.database_url,
-        pool_pre_ping=True
+        settings.DATABASE_URL,
+        pool_pre_ping=True,
     )
 
     mapper_registry.metadata.create_all(engine)
@@ -49,6 +51,7 @@ def Session(database_engine):
     return sessionmaker(
         autocommit=False,
         autoflush=False,
+        expire_on_commit=False,
         bind=database_engine
     )
 
@@ -172,7 +175,7 @@ def user_repository():
             return self.result
 
         def getByEmail(self, email):
-            self.calls.append(['getByISBN', [email]])
+            self.calls.append(['getByEmail', [email]])
             return self.result
 
         def add(self, user):

--- a/server/tests/test_routes.py
+++ b/server/tests/test_routes.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from unittest.mock import MagicMock
 from http import HTTPStatus
@@ -11,16 +12,13 @@ class TestSearchBook:
     ):
         book = create_book()
         mock_api = MagicMock(return_value=book)
-        settings_override({
-            'configured_apis': [mock_api],
-            'uow': uow
-        })
+        settings_override({"configured_apis": [mock_api], "uow": uow})
 
         response = test_client.get(f"/books/search/{book.isbn}")
         assert response.status_code == HTTPStatus.OK
         assert jsonable_encoder(book) == json.loads(response.read().decode())
-        assert uow.books.calls[0] == ['getByISBN', [book.isbn]]
-        assert uow.books.calls[1] == ['add', [book]]
+        assert uow.books.calls[0] == ["getByISBN", [book.isbn]]
+        assert uow.books.calls[1] == ["add", [book]]
         mock_api.assert_called_once_with(book.isbn)
 
     def test_returns_book_when_found_in_repository(
@@ -29,26 +27,83 @@ class TestSearchBook:
         book = create_book()
         uow.books.result = book
         mock_api = MagicMock(return_value=book)
-        settings_override({
-            'configured_apis': [mock_api],
-            'uow': uow
-        })
+        settings_override({"configured_apis": [mock_api], "uow": uow})
 
         response = test_client.get(f"/books/search/{book.isbn}")
         assert response.status_code == HTTPStatus.OK
         assert jsonable_encoder(book) == json.loads(response.read().decode())
         mock_api.assert_not_called()
-        assert uow.books.calls == [['getByISBN', [book.isbn]]]
+        assert uow.books.calls == [["getByISBN", [book.isbn]]]
 
     def test_returns_not_found_when_book_can_not_be_fetched(
         self, test_client, settings_override, uow
     ):
         mock_api = MagicMock(return_value=None)
-        settings_override({
-            'configured_apis': [mock_api],
-            'uow': uow
-        })
+        settings_override({"configured_apis": [mock_api], "uow": uow})
 
         response = test_client.get("/books/search/1")
 
         assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+class TestCreateUser:
+    def test_returns_created_user(self, test_client, database_engine):
+        email = 'valid@mail.co'
+        password = 'this is a valid password'
+
+        response = test_client.post("/user/create", json={
+            'email': email,
+            'password': password
+        })
+        created_user_dict = json.loads(response.read().decode())
+
+        assert response.status_code == HTTPStatus.CREATED
+        assert created_user_dict['email'] == email
+
+    def test_returns_error_when_user_creations_fails(
+        self, test_client, database_engine
+    ):
+        invalid_email = 'invalid.email'
+        password = 'this is a valid password'
+
+        response = test_client.post("/user/create", json={
+            'email': invalid_email,
+            'password': password
+        })
+        response_data = json.loads(response.text)
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert response_data['detail'] == 'Unable to create user!'
+
+
+class TestTokenCreation:
+    @pytest.fixture(autouse=True)
+    def setup(self, Session, create_stored_user):
+        self.email = 'valid@mail.co'
+        self.password = 'this is a valid password'
+
+        with Session() as session:
+            create_stored_user(session, self.email, self.password)
+
+    def test_creates_toke_for_user(
+        self, test_client,
+    ):
+        response = test_client.post("/token", data={
+            'username': self.email,
+            'password': self.password
+        })
+        response_data = json.loads(response.text)
+
+        assert response.status_code == HTTPStatus.OK
+        assert response_data['token_type'] == 'bearer'
+        assert response_data['access_token'] is not None
+
+    def test_raises_unauthorized_for_invalid_credentials(self, test_client):
+        response = test_client.post("/token", data={
+            'username': self.email,
+            'password': 'wrong password'
+        })
+        response_data = json.loads(response.text)
+
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert response_data['detail'] == 'Incorrect username or password'

--- a/server/tests/test_services.py
+++ b/server/tests/test_services.py
@@ -1,0 +1,130 @@
+import pytest
+import uuid
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+from jose import jwt
+
+from src.services import (
+    authenticate_user, create_access_token, create_user, validate_token
+)
+from src import password_context, settings
+
+
+class TestCreateUser:
+    def test_able_to_create_user(self, uow):
+        email = 'test@mail.com'
+        password = '12345678'
+
+        user = create_user(uow, email, password)
+        created_user = uow.users.calls[1][1][0]
+
+        assert uow.calls[0] == ['commit']
+        assert uow.users.calls[1][0] == 'add'
+        assert created_user.email == email
+        assert password_context.verify(password, created_user.password)
+        assert user == created_user
+
+    @pytest.mark.parametrize('invalid_email', [
+        'test', 'test@mail', 'mail.com'
+    ])
+    def test_should_fail_if_invalid_email(self, uow, invalid_email):
+        with pytest.raises(ValueError):
+            create_user(uow, invalid_email, 'password')
+
+    @pytest.mark.parametrize('invalid_password', [
+        '', '1234567', None
+    ])
+    def test_should_fail_for_invalid_passoword(
+        self, uow, invalid_password
+    ):
+        with pytest.raises(ValueError) as error:
+            create_user(uow, 'test@mail.com', invalid_password)
+
+            assert str(error) == 'Unable to create user!'
+
+    def test_should_fail_for_duplicate_email(self, uow):
+        email = 'test@mail.com'
+        password = '12345678'
+
+        uow.users.result = create_user(uow, email, password)
+
+        with pytest.raises(ValueError) as error:
+            create_user(uow, email, password)
+            assert str(error) == 'Unable to create user!'
+
+
+class TestAuthenticateUser:
+    def test_authenticates_user(self, uow):
+        password = '12345678'
+        user = create_user(uow, 'test@mail.com', password)
+        uow.users.result = user
+
+        authenticated_user = authenticate_user(uow, user.email, password)
+
+        assert authenticated_user == user
+
+    def test_fails_if_email_not_found(self, uow):
+        email = 'test@mail.com'
+        uow.users.result = None
+
+        authenticated_user = authenticate_user(uow, email, '')
+
+        assert authenticated_user is None
+        assert uow.users.calls.pop() == ['getByEmail', [email]]
+
+    def test_fails_for_invalid_password(self, uow):
+        user = create_user(uow, 'test@mail.com', '12345678')
+        uow.users.result = user
+
+        authenticated_user = authenticate_user(uow, user.email, '')
+
+        assert authenticated_user is None
+
+
+class TestValidateToken:
+    def test_validates_correct_token(self, uow):
+        user = create_user(uow, 'dummy@mail.com', '12345678')
+        uow.users.result = user
+        token = create_access_token(user.id)
+
+        validate_token(uow, token)
+
+    def test_fails_if_user_not_found(self, uow):
+        user_id = uuid.uuid4()
+        token = create_access_token(user_id)
+
+        with pytest.raises(PermissionError):
+            validate_token(uow, token)
+
+    def test_failse_if_token_expired(self, uow):
+        user_id = uuid.uuid4()
+        token = create_access_token(user_id)
+
+        with pytest.raises(PermissionError):
+            validate_token(uow, token)
+
+
+class TestCreateAccesToken:
+    def test_creates_access_token(self, monkeypatch):
+        token = 'token'
+        user_id = uuid.uuid4()
+        jwt.encode = MagicMock(return_value='token')
+        timestamp = datetime(1212, 12, 12, 12, 12, 12)
+
+        payload = {
+            'sub': str(user_id),
+            'exp': (
+                timestamp
+                + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+            )
+        }
+
+        created_token = create_access_token(user_id, timestamp)
+
+        assert token == created_token
+        jwt.encode.assert_called_once_with(
+            payload,
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM
+        )


### PR DESCRIPTION
**Scope**
 - Inorder to have some kind of restricion on who can enter the site we need to create some level of authentication
 - Also we need to create users, of whom we can authenticate

**Development**
 - Created new services for:
   - user creation and authentication
   - token creation and validation
 - Created two new endpoints
   - one with which a user can create an access token
   - one with which a user can create a new user.
 - New test for routes were created as integration test (they are using the actual Postgres server
 - Service tests were created as unit tests
 - Added `expire_on_commit=False` flag to session creation, so we can use the created object after a session has been rolled back